### PR TITLE
Revert "modify jsoncpp because we aren't using stdc++11"

### DIFF
--- a/src/lib_json/json_writer.cpp
+++ b/src/lib_json/json_writer.cpp
@@ -15,7 +15,6 @@
 #include <math.h>
 #include <stdio.h>
 #include <string.h>
-#include <boost/shared_ptr.hpp>
 
 #if defined(_MSC_VER) && _MSC_VER < 1500 // VC++ 8.0 and below
 #include <float.h>
@@ -1018,14 +1017,14 @@ StreamWriter* OldCompressingStreamWriterBuilder::newStreamWriter(
 
 std::string writeString(Value const& root, StreamWriter::Factory const& builder) {
   std::ostringstream sout;
-  boost::shared_ptr<StreamWriter> const sw(builder.newStreamWriter(&sout));
+  std::unique_ptr<StreamWriter> const sw(builder.newStreamWriter(&sout));
   sw->write(root);
   return sout.str();
 }
 
 std::ostream& operator<<(std::ostream& sout, Value const& root) {
   StreamWriterBuilder builder;
-  boost::shared_ptr<StreamWriter> writer(builder.newStreamWriter(&sout));
+  std::shared_ptr<StreamWriter> writer(builder.newStreamWriter(&sout));
   writer->write(root);
   return sout;
 }


### PR DESCRIPTION
This reverts commit 715bf7216319c265f0ba2cdf806b94f93b7bb4d1.

This removes our dependency on boost since since we are using at least c++11 everywhere now.