### PR TITLE
Fix For MSVC

### DIFF
--- a/src/lib_json/json_reader.cpp
+++ b/src/lib_json/json_reader.cpp
@@ -603,9 +603,9 @@ bool Reader::decodeDouble(Token& token, Value& decoded) {
   IStringStream is(buffer);
   is.imbue( std::locale::classic() );
   if (!(is >> value)) {
-    if (value == std::numeric_limits<double>::max())
+    if (buffer.length() > 0 && buffer[0] != '-')
       value = std::numeric_limits<double>::infinity();
-    else if (value == std::numeric_limits<double>::lowest())
+    else if (buffer.length() > 0 && buffer[0] == '-')
       value = -std::numeric_limits<double>::infinity();
     else if (!std::isinf(value))
       return addError(


### PR DESCRIPTION
## Introduction

This fixes a conversion problem that happens in Microsoft's Visual Studio but not GCC/Clang

## Details

Consider this very simple code sample:
```cpp
#include <cmath>
#include <iostream>
#include <limits>
#include <sstream>
#include <string>

double MyStringToDouble( const std::string& s )
{
   double result = 0;
   std::istringstream is( s );
   is.imbue( std::locale::classic() );
   if ( !( is >> result ) )
   {
      if ( result == std::numeric_limits<double>::max() )
         result = std::numeric_limits<double>::infinity();
      else if ( result == std::numeric_limits<double>::lowest() )
         result = -std::numeric_limits<double>::infinity();
      else if ( !std::isinf( result ) )
      {
         return 0;
      }
   }
   return result;
}

int main()
{
   std::cout << "TestA: " << MyStringToDouble( "123" ) << std::endl;
   std::cout << "TestB: " << MyStringToDouble( "-1.79769313486232e+308" ) << std::endl;
   std::cout << "TestC: " << MyStringToDouble( "2e+999" ) << std::endl;
}
```

On both GCC & Clang it gives the desired output (online output: https://godbolt.org/z/ese41nK6a) of `-inf`/`inf`:
![image](https://user-images.githubusercontent.com/3475163/221616154-0ef0c1e1-0ed0-4a06-8a81-8a1fb22e153a.png)

But in Microsoft compiler inside that `if`-statement `result` has not changed and is still the value `0`:
![image](https://user-images.githubusercontent.com/3475163/221616311-5cfa869d-9a4a-4bcb-b51e-511c4c6adb23.png)

Meaning it doesn't match either of the `-inf`/`inf` cases:
![image](https://user-images.githubusercontent.com/3475163/221616790-ab4aefd3-f184-43a3-872f-54cb7aa053fe.png)

So this is to make it work with MSVC.  The solution I went with is just look at the first character.  If it is the negative (`-`) character return `-inf` and if not use `inf`.

## Testing Notes

It did work for my small test cases I tested with and am writing a client-side test for this.

Hope that helps! :smiley: