### PR TITLE
Reduce the JSONCPP_DEPRECATED_STACK_LIMIT to 500.

### DIFF
--- a/src/lib_json/json_reader.cpp
+++ b/src/lib_json/json_reader.cpp
@@ -44,8 +44,16 @@
 
 // Define JSONCPP_DEPRECATED_STACK_LIMIT as an appropriate integer at compile
 // time to change the stack limit
+// NOTE:LEA: reduced JSONCPP_DEPRECATED_STACK_LIMIT from 1000 to 500. This is the stack limit
+//           of the Reader::nodes_ and not the call stack limit of the system. At 1000, with a
+//           json file designed to cause stack overflow (as a hacking tool) this would overflow
+//           the system callstack when the Reader::nodes_ was only at 662 or so
+//           For Techsmith's purposes, we never have project nodes nested so deeply, so 500 seems
+//           like a perfectly reasonable limit and should not cause any projects to fail to load.
+//           Also, when trying to create that deep a nesting by repeated grouping of a media,
+//           Camtasiaa failed at ~150 levels deep so I could not get anywhere near 500.
 #if !defined(JSONCPP_DEPRECATED_STACK_LIMIT)
-#define JSONCPP_DEPRECATED_STACK_LIMIT 1000
+#define JSONCPP_DEPRECATED_STACK_LIMIT 500
 #endif
 
 static size_t const stackLimit_g =


### PR DESCRIPTION
This fixes the issues that the security team found here: https://github.com/TechSmith/CamtasiaWin/issues/23300.
That issue contains a link to 4 projects that crashed Camtasia Windows. Those now fail to import rather than crash the application.